### PR TITLE
Aizad/FEQ-1442/Input Component

### DIFF
--- a/lib/components/Input/HelperMessage.tsx
+++ b/lib/components/Input/HelperMessage.tsx
@@ -1,16 +1,31 @@
-import React from "react";
+import React, { ReactNode } from "react";
 import clsx from "clsx";
+import { InputVariants } from ".";
 import "./Input.scss";
 
 export interface HelperMessageProps {
-  message?: string;
-  hasError?: boolean;
+  error?: boolean;
+  message?: ReactNode;
+  variant?: InputVariants;
+  disabled?: boolean;
 }
 
-const HelperMessage = ({ message, hasError }: HelperMessageProps) => (
+const MessageVariant: Record<InputVariants, string> = {
+  general: "deriv-helper-message__general",
+  success: "deriv-helper-message__success",
+  error: "deriv-helper-message__error",
+};
+
+const HelperMessage = ({
+  error,
+  message,
+  variant = "general",
+  disabled,
+}: HelperMessageProps) => (
   <p
     className={clsx("deriv-helper-message", {
-      "deriv-helper-message__error": hasError,
+      [MessageVariant["general"]]: disabled,
+      [MessageVariant[error ? "error" : variant]]: !disabled,
     })}
   >
     {message}

--- a/lib/components/Input/HelperMessage.tsx
+++ b/lib/components/Input/HelperMessage.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import clsx from "clsx";
+import "./Input.scss";
+
+export interface HelperMessageProps {
+  message?: string;
+  hasError?: boolean;
+}
+
+const HelperMessage = ({ message, hasError }: HelperMessageProps) => (
+  <p
+    className={clsx("deriv-helper-message", {
+      "deriv-helper-message__error": hasError,
+    })}
+  >
+    {message}
+  </p>
+);
+
+export default HelperMessage;

--- a/lib/components/Input/Input.scss
+++ b/lib/components/Input/Input.scss
@@ -18,17 +18,11 @@ $border: 1px solid;
     width: 328px;
     box-sizing: border-box;
     outline: none;
-    border: $border $inactive_color;
     text-align: left;
     &:disabled {
       border: $border $disabled_color;
       color: $inactive_color;
     }
-
-    &:focus {
-      border: $border $active_color;
-    }
-
     &:focus,
     &:not(:focus):not([value=""]) {
       & ~ label {
@@ -39,11 +33,22 @@ $border: 1px solid;
         height: fit-content;
       }
     }
-
+    &__general {
+      border: $border $inactive_color;
+      &:focus {
+        border: $border $active_color;
+      }
+    }
     &__error {
       border: $border $error_field;
       &:focus {
         border: $border $error_field;
+      }
+    }
+    &__success {
+      border: $border $success_color;
+      &:focus {
+        border: $border $success_color;
       }
     }
   }
@@ -57,12 +62,17 @@ $border: 1px solid;
     display: flex;
     align-items: center;
     pointer-events: none;
-    color: $inactive_color;
     text-transform: capitalize;
     transition: all 0.15s ease-out;
     padding: 0;
+    &__general {
+      color: $inactive_color;
+    }
     &__error {
       color: $error_field;
+    }
+    &__success {
+      color: $success_color;
     }
   }
 
@@ -73,7 +83,9 @@ $border: 1px solid;
   }
 }
 
-.deriv-input--field:disabled + .deriv-input--label {
+.deriv-input--field__general:disabled + .deriv-input--label,
+.deriv-input--field__error:disabled + .deriv-input--label,
+.deriv-input--field__success:disabled + .deriv-input--label {
   color: $inactive_color;
   cursor: not-allowed;
 }
@@ -86,12 +98,21 @@ $border: 1px solid;
   color: $error_field;
 }
 
+.deriv-input--field__success:focus + .deriv-input--label {
+  color: $success_color;
+}
+
 .deriv-helper-message {
   font-size: 12px;
   font-style: normal;
   font-weight: 400;
   line-height: 18px;
-  color: $inactive_color;
+  &__general {
+    color: $inactive_color;
+  }
+  &__success {
+    color: $success_color;
+  }
   &__error {
     color: $error_field;
   }

--- a/lib/components/Input/Input.scss
+++ b/lib/components/Input/Input.scss
@@ -2,11 +2,11 @@ $inactive_field: #d6dadb;
 $active_field: #85acb0;
 $success_field: #4bb4b3;
 $error_field: #ec3f3f;
-$general_text: #999999;
+$inactive_text: #999999;
 $border: 1px solid;
 
 .deriv-input-container {
-  display: block;
+  display: inline-block;
   position: relative;
 }
 
@@ -18,6 +18,7 @@ $border: 1px solid;
   border-radius: 4px;
   width: 328px;
   box-sizing: border-box;
+  display: inline-flex;
 }
 
 .deriv-input-label {
@@ -28,6 +29,7 @@ $border: 1px solid;
   display: flex;
   align-items: center;
   pointer-events: none;
+  color: $inactive_text;
 }
 
 .deriv-input-field,
@@ -35,6 +37,7 @@ $border: 1px solid;
   font-size: 14px;
   line-height: 20px;
   font-weight: 400;
+  text-align: left;
 }
 
 .deriv-input-field:focus {

--- a/lib/components/Input/Input.scss
+++ b/lib/components/Input/Input.scss
@@ -1,74 +1,81 @@
-$inactive_field: #d6dadb;
-$active_field: #85acb0;
-$success_field: #4bb4b3;
+$disabled_color: #d6d6d6;
+$inactive_color: #999999;
+$active_color: #85acb0;
+$success_color: #4bb4b3;
 $error_field: #ec3f3f;
-$inactive_text: #999999;
+$inactive_color: #999999;
 $border: 1px solid;
 
-.deriv-input-container {
+.deriv-input {
   display: inline-block;
   position: relative;
+
+  &--field {
+    width: 100%;
+    padding: 10px 16px;
+    outline: none;
+    border-radius: 4px;
+    width: 328px;
+    box-sizing: border-box;
+    outline: none;
+    border: $border $inactive_color;
+    text-align: left;
+    &:disabled {
+      border: $border $disabled_color;
+      color: $inactive_color;
+    }
+
+    &:focus {
+      border: $border $active_color;
+    }
+
+    &:focus,
+    &:not(:focus):not([value=""]) {
+      & ~ label {
+        font-size: 10px;
+        transform: translate(0, -50%);
+        background-color: #ffffff;
+        padding: 0px 4px;
+        height: fit-content;
+      }
+    }
+
+    &__error {
+      border: $border $error_field;
+      &:focus {
+        border: $border $error_field;
+      }
+    }
+  }
+
+  &--label {
+    display: inline-block;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 16px;
+    display: flex;
+    align-items: center;
+    pointer-events: none;
+    color: $inactive_color;
+    text-transform: capitalize;
+    transition: all 0.15s ease-out;
+    padding: 0;
+    &__error {
+      color: $error_field;
+    }
+  }
 }
 
-.deriv-input-field {
-  width: 100%;
-  padding: 10px 16px;
-  border: $border $inactive_field;
-  outline: none;
-  border-radius: 4px;
-  width: 328px;
-  box-sizing: border-box;
-  display: inline-flex;
+.deriv-input--field:disabled + .deriv-input--label {
+  color: $inactive_color;
+  cursor: not-allowed;
 }
 
-.deriv-input-label {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 16px;
-  display: flex;
-  align-items: center;
-  pointer-events: none;
-  color: $inactive_text;
+.deriv-input--field:focus + .deriv-input--label {
+  color: $active_color;
 }
 
-.deriv-input-field,
-.deriv-input-label .deriv-input-label-text {
-  font-size: 14px;
-  line-height: 20px;
-  font-weight: 400;
-  text-align: left;
-}
-
-.deriv-input-field:focus {
-  outline: none;
-  border: $border $active_field;
-}
-
-.deriv-input-field:focus + .deriv-input-label .deriv-input-label-text {
-  font-size: 10px;
-  transform: translate(0, -100%);
-  background-color: white;
-  padding-left: 4px;
-  padding-right: 4px;
-  color: $active_field;
-}
-
-.deriv-input-label .deriv-input-label-text {
-  transition: all 0.15s ease-out;
-}
-
-.deriv-input-field:focus + .deriv-input-label .deriv-input-label-text,
-:not(.deriv-input-field[value=""])
-  + .deriv-input-label
-  .deriv-input-label-text {
-  font-size: 10px;
-  transform: translate(0, -100%);
-  background-color: white;
-  padding-left: 4px;
-  padding-right: 4px;
-}
-
-.deriv-input-field:focus + .deriv-input-label .deriv-input-label-text {
-  color: $active_field;
+.deriv-input--field__error:focus + .deriv-input--label {
+  color: $error_field;
 }

--- a/lib/components/Input/Input.scss
+++ b/lib/components/Input/Input.scss
@@ -65,6 +65,12 @@ $border: 1px solid;
       color: $error_field;
     }
   }
+
+  &--helper-message {
+    position: absolute;
+    left: 16px;
+    margin-top: 2px;
+  }
 }
 
 .deriv-input--field:disabled + .deriv-input--label {
@@ -78,4 +84,15 @@ $border: 1px solid;
 
 .deriv-input--field__error:focus + .deriv-input--label {
   color: $error_field;
+}
+
+.deriv-helper-message {
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 18px;
+  color: $inactive_color;
+  &__error {
+    color: $error_field;
+  }
 }

--- a/lib/components/Input/Input.scss
+++ b/lib/components/Input/Input.scss
@@ -1,0 +1,71 @@
+$inactive_field: #d6dadb;
+$active_field: #85acb0;
+$success_field: #4bb4b3;
+$error_field: #ec3f3f;
+$general_text: #999999;
+$border: 1px solid;
+
+.deriv-input-container {
+  display: block;
+  position: relative;
+}
+
+.deriv-input-field {
+  width: 100%;
+  padding: 10px 16px;
+  border: $border $inactive_field;
+  outline: none;
+  border-radius: 4px;
+  width: 328px;
+  box-sizing: border-box;
+}
+
+.deriv-input-label {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 16px;
+  display: flex;
+  align-items: center;
+  pointer-events: none;
+}
+
+.deriv-input-field,
+.deriv-input-label .deriv-input-label-text {
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 400;
+}
+
+.deriv-input-field:focus {
+  outline: none;
+  border: $border $active_field;
+}
+
+.deriv-input-field:focus + .deriv-input-label .deriv-input-label-text {
+  font-size: 10px;
+  transform: translate(0, -100%);
+  background-color: white;
+  padding-left: 4px;
+  padding-right: 4px;
+  color: $active_field;
+}
+
+.deriv-input-label .deriv-input-label-text {
+  transition: all 0.15s ease-out;
+}
+
+.deriv-input-field:focus + .deriv-input-label .deriv-input-label-text,
+:not(.deriv-input-field[value=""])
+  + .deriv-input-label
+  .deriv-input-label-text {
+  font-size: 10px;
+  transform: translate(0, -100%);
+  background-color: white;
+  padding-left: 4px;
+  padding-right: 4px;
+}
+
+.deriv-input-field:focus + .deriv-input-label .deriv-input-label-text {
+  color: $active_field;
+}

--- a/lib/components/Input/Input.scss
+++ b/lib/components/Input/Input.scss
@@ -23,8 +23,11 @@ $border: 1px solid;
       border: $border $disabled_color;
       color: $inactive_color;
     }
+    &::placeholder {
+      visibility: hidden;
+    }
     &:focus,
-    &:not(:focus):not([value=""]) {
+    &:not(:placeholder-shown) {
       & ~ label {
         font-size: 10px;
         transform: translate(0, -50%);
@@ -80,6 +83,12 @@ $border: 1px solid;
     position: absolute;
     left: 16px;
     margin-top: 2px;
+  }
+
+  &--right-content {
+    position: absolute;
+    right: 16px;
+    bottom: 25%;
   }
 }
 

--- a/lib/components/Input/index.tsx
+++ b/lib/components/Input/index.tsx
@@ -1,0 +1,37 @@
+import React, { ComponentProps } from "react";
+import "./Input.scss";
+
+type InputProps = {
+  className?: string;
+  disabled?: boolean;
+  helpLineMessage?: string;
+  label?: string;
+  name?: ComponentProps<"input">["name"];
+  onChange?: ComponentProps<"input">["onChange"];
+  type?: ComponentProps<"input">["type"];
+  value?: ComponentProps<"input">["value"];
+};
+
+export const Input = ({
+  disabled = false,
+  label = "input",
+  name = "input",
+  onChange,
+  type = "text",
+  value,
+}: InputProps) => (
+  <div className="deriv-input-container">
+    <input
+      className="deriv-input-field"
+      type={type}
+      id={label}
+      value={value}
+      name={name}
+      onChange={onChange}
+      disabled={disabled}
+    />
+    <label className="deriv-input-label" htmlFor={label}>
+      <p className="deriv-input-label-text">{label}</p>
+    </label>
+  </div>
+);

--- a/lib/components/Input/index.tsx
+++ b/lib/components/Input/index.tsx
@@ -1,37 +1,39 @@
-import React, { ComponentProps } from "react";
+import React, { ChangeEvent, ComponentProps, useState } from "react";
+import clsx from "clsx";
 import "./Input.scss";
 
-type InputProps = {
-  className?: string;
-  disabled?: boolean;
-  helpLineMessage?: string;
+interface InputProps
+  extends Omit<ComponentProps<"input">, "style" | "placeholder"> {
   label?: string;
-  name?: ComponentProps<"input">["name"];
-  onChange?: ComponentProps<"input">["onChange"];
-  type?: ComponentProps<"input">["type"];
-  value?: ComponentProps<"input">["value"];
-};
+  helperMessage?: string;
+  error?: boolean;
+}
 
-export const Input = ({
-  disabled = false,
-  label = "input",
-  name = "input",
-  onChange,
-  type = "text",
-  value,
-}: InputProps) => (
-  <div className="deriv-input-container">
-    <input
-      className="deriv-input-field"
-      type={type}
-      id={label}
-      value={value}
-      name={name}
-      onChange={onChange}
-      disabled={disabled}
-    />
-    <label className="deriv-input-label" htmlFor={label}>
-      <p className="deriv-input-label-text">{label}</p>
-    </label>
-  </div>
-);
+export const Input = ({ label, id, error, ...rest }: InputProps) => {
+  const [value, setValue] = useState("");
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+  };
+
+  return (
+    <div className="deriv-input">
+      <input
+        className={clsx("deriv-input--field", {
+          "deriv-input--field__error": error,
+        })}
+        id={id}
+        value={value}
+        onChange={handleChange}
+        {...rest}
+      />
+      <label
+        className={clsx("deriv-input--label", {
+          "deriv-input--label__error": error,
+        })}
+        htmlFor={id}
+      >
+        {label}
+      </label>
+    </div>
+  );
+};

--- a/lib/components/Input/index.tsx
+++ b/lib/components/Input/index.tsx
@@ -1,22 +1,37 @@
 import React, { ChangeEvent, ComponentProps, ReactNode, useState } from "react";
 import clsx from "clsx";
-import HelperMessage, { HelperMessageProps } from "./HelperMessage";
+import HelperMessage from "./HelperMessage";
 import "./Input.scss";
 
+export type InputVariants = "general" | "success" | "error";
 interface InputProps
-  extends Omit<ComponentProps<"input">, "style" | "placeholder">,
-    HelperMessageProps {
+  extends Omit<ComponentProps<"input">, "style" | "placeholder"> {
   label?: string;
-  hasError?: boolean;
   hasRightPlaceholder?: ReactNode;
+  error?: boolean;
+  variant?: InputVariants;
+  message?: ReactNode;
 }
+
+const InputVariant: Record<InputVariants, string> = {
+  general: "deriv-input--field__general",
+  success: "deriv-input--field__success",
+  error: "deriv-input--field__error",
+};
+
+const LabelVariant: Record<InputVariants, string> = {
+  general: "deriv-input--label__general",
+  success: "deriv-input--label__success",
+  error: "deriv-input--label__error",
+};
 
 export const Input = ({
   label,
   id,
-  hasError,
+  error,
   message,
   hasRightPlaceholder,
+  variant = "general",
   ...rest
 }: InputProps) => {
   const [value, setValue] = useState("");
@@ -28,19 +43,21 @@ export const Input = ({
   return (
     <div className="deriv-input">
       <input
-        className={clsx("deriv-input--field", {
-          "deriv-input--field__error": hasError,
-          className: rest.className,
-        })}
+        className={clsx(
+          "deriv-input--field",
+          { className: rest.className },
+          InputVariant[error ? "error" : variant]
+        )}
         id={id}
         value={value}
         onChange={handleChange}
         {...rest}
       />
       <label
-        className={clsx("deriv-input--label", {
-          "deriv-input--label__error": hasError,
-        })}
+        className={clsx(
+          "deriv-input--label",
+          LabelVariant[error ? "error" : variant]
+        )}
         htmlFor={id}
       >
         {label}
@@ -49,7 +66,14 @@ export const Input = ({
         <div className="deriv-input--right-content">{hasRightPlaceholder}</div>
       )}
       <div className="deriv-input--helper-message">
-        {message && <HelperMessage message={message} hasError={hasError} />}
+        {message && (
+          <HelperMessage
+            message={message}
+            variant={variant}
+            error={error}
+            disabled={rest.disabled}
+          />
+        )}
       </div>
     </div>
   );

--- a/lib/components/Input/index.tsx
+++ b/lib/components/Input/index.tsx
@@ -32,6 +32,8 @@ export const Input = ({
   message,
   hasRightPlaceholder,
   variant = "general",
+  className,
+  disabled,
   ...rest
 }: InputProps) => {
   return (
@@ -40,7 +42,7 @@ export const Input = ({
         placeholder={label}
         className={clsx(
           "deriv-input--field",
-          { className: rest.className },
+          className,
           InputVariant[error ? "error" : variant]
         )}
         id={id}
@@ -64,7 +66,7 @@ export const Input = ({
             message={message}
             variant={variant}
             error={error}
-            disabled={rest.disabled}
+            disabled={disabled}
           />
         )}
       </div>

--- a/lib/components/Input/index.tsx
+++ b/lib/components/Input/index.tsx
@@ -1,25 +1,36 @@
-import React, { ChangeEvent, ComponentProps, useState } from "react";
+import React, { ChangeEvent, ComponentProps, ReactNode, useState } from "react";
 import clsx from "clsx";
+import HelperMessage, { HelperMessageProps } from "./HelperMessage";
 import "./Input.scss";
 
 interface InputProps
-  extends Omit<ComponentProps<"input">, "style" | "placeholder"> {
+  extends Omit<ComponentProps<"input">, "style" | "placeholder">,
+    HelperMessageProps {
   label?: string;
-  helperMessage?: string;
-  error?: boolean;
+  hasError?: boolean;
+  hasRightPlaceholder?: ReactNode;
 }
 
-export const Input = ({ label, id, error, ...rest }: InputProps) => {
+export const Input = ({
+  label,
+  id,
+  hasError,
+  message,
+  hasRightPlaceholder,
+  ...rest
+}: InputProps) => {
   const [value, setValue] = useState("");
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
+    rest.onChange?.(e);
   };
 
   return (
     <div className="deriv-input">
       <input
         className={clsx("deriv-input--field", {
-          "deriv-input--field__error": error,
+          "deriv-input--field__error": hasError,
+          className: rest.className,
         })}
         id={id}
         value={value}
@@ -28,12 +39,18 @@ export const Input = ({ label, id, error, ...rest }: InputProps) => {
       />
       <label
         className={clsx("deriv-input--label", {
-          "deriv-input--label__error": error,
+          "deriv-input--label__error": hasError,
         })}
         htmlFor={id}
       >
         {label}
       </label>
+      {hasRightPlaceholder && (
+        <div className="deriv-input--right-content">{hasRightPlaceholder}</div>
+      )}
+      <div className="deriv-input--helper-message">
+        {message && <HelperMessage message={message} hasError={hasError} />}
+      </div>
     </div>
   );
 };

--- a/lib/components/Input/index.tsx
+++ b/lib/components/Input/index.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, ComponentProps, ReactNode, useState } from "react";
+import React, { ComponentProps, ReactNode } from "react";
 import clsx from "clsx";
 import HelperMessage from "./HelperMessage";
 import "./Input.scss";
@@ -34,23 +34,16 @@ export const Input = ({
   variant = "general",
   ...rest
 }: InputProps) => {
-  const [value, setValue] = useState("");
-  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-    setValue(e.target.value);
-    rest.onChange?.(e);
-  };
-
   return (
     <div className="deriv-input">
       <input
+        placeholder={label}
         className={clsx(
           "deriv-input--field",
           { className: rest.className },
           InputVariant[error ? "error" : variant]
         )}
         id={id}
-        value={value}
-        onChange={handleChange}
         {...rest}
       />
       <label

--- a/lib/components/Input/index.tsx
+++ b/lib/components/Input/index.tsx
@@ -7,7 +7,7 @@ export type InputVariants = "general" | "success" | "error";
 interface InputProps
   extends Omit<ComponentProps<"input">, "style" | "placeholder"> {
   label?: string;
-  hasRightPlaceholder?: ReactNode;
+  rightPlaceholder?: ReactNode;
   error?: boolean;
   variant?: InputVariants;
   message?: ReactNode;
@@ -30,7 +30,7 @@ export const Input = ({
   id,
   error,
   message,
-  hasRightPlaceholder,
+  rightPlaceholder,
   variant = "general",
   className,
   disabled,
@@ -57,8 +57,8 @@ export const Input = ({
       >
         {label}
       </label>
-      {hasRightPlaceholder && (
-        <div className="deriv-input--right-content">{hasRightPlaceholder}</div>
+      {rightPlaceholder && (
+        <div className="deriv-input--right-content">{rightPlaceholder}</div>
       )}
       <div className="deriv-input--helper-message">
         {message && (

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -3,3 +3,4 @@ export { Button } from "./components/Button";
 export { Text } from "./components/Text";
 export { Tab, Tabs } from "./components/Tabs";
 export { Tooltip } from "./components/Tooltip";
+export { Input } from "./components/Input";


### PR DESCRIPTION
Created Input component with base stylings.
This input component can be extended to Text field, Password Field and Text Area.
It currently has these states: `active` & `disabled`.
It currently has these variants: `general`, `success` & `error`.
It comes with `HelperMessage` where based on the variant or the state of the input component it will change its color.
It has the option to pass text or icon on the right side of the input.
It is uncontrolled so you can use any third party libraries.   


https://github.com/deriv-com/ui/assets/103104395/c158e049-23f9-4ae9-b533-edfa5132a353







