### PR TITLE
[FEQ] Shayan/FEQ-1503/Refactor: made tab panel optional

### DIFF
--- a/lib/components/Tabs/Tab.tsx
+++ b/lib/components/Tabs/Tab.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 
 type TabProps = {
-    children: ReactNode;
+    children?: ReactNode;
     icon?: ReactNode;
     title: string;
 };

--- a/lib/components/Tabs/TabTitle.tsx
+++ b/lib/components/Tabs/TabTitle.tsx
@@ -10,11 +10,13 @@ export type TabTitleProps = {
     title: string;
     className?: string;
     variant: 'primary' | 'secondary';
+    onClickHandler?: () => void;
 };
 
-const TabTitle = ({ icon, activeTab, isActive, setSelectedTab, title,className,variant }: TabTitleProps) => {
+const TabTitle = ({ icon, activeTab, isActive, setSelectedTab, title,className,variant, onClickHandler }: TabTitleProps) => {
     const handleOnClick = useCallback((title: string) => {
         setSelectedTab(title);
+        onClickHandler?.();
     }, [setSelectedTab, activeTab]);
 
     const classNameVariants: Record<TabTitleProps['variant'], string> = {

--- a/lib/components/Tabs/Tabs.tsx
+++ b/lib/components/Tabs/Tabs.tsx
@@ -9,9 +9,10 @@ type TabsProps = {
     wrapperClassName?: string;
     className?: string;
     variant?: 'primary' | 'secondary';
+    onClickHandler?: () => void;
 };
 
-const Tabs = ({ children, activeTab, wrapperClassName, className, variant = 'primary' }: TabsProps): JSX.Element => {
+const Tabs = ({ children, activeTab, wrapperClassName, className, variant = 'primary', onClickHandler }: TabsProps): JSX.Element => {
     const [selectedTab, setSelectedTab] = useState(activeTab || children[0].props.title);
 
     return (
@@ -27,6 +28,7 @@ const Tabs = ({ children, activeTab, wrapperClassName, className, variant = 'pri
                             setSelectedTab={setSelectedTab}
                             title={item.props.title}
                             variant={variant}
+                            onClickHandler={onClickHandler}
                         />
                     )
                 })}


### PR DESCRIPTION
Changes:

- added onClickHandler as an optional props 
- the tab panel is now optional so this component can be use as both `Tab` and `SwitcherItem`