### PR TITLE
[FEQ] aum/FEQ-1579/PageLayout-component

### DIFF
--- a/lib/components/Layout/PageLayout.scss
+++ b/lib/components/Layout/PageLayout.scss
@@ -1,28 +1,30 @@
 .layout {
     width: 100%;
-    height: calc(100vh - 8.4rem);
     display: flex;
-    justify-content: space-around;
-
-    padding: 1.5rem;
+    gap: 1.5rem;
+    padding-top: 1.5rem;
     background: white;
+
+    @include mobile {
+        flex-direction: column;
+    }
 
     &__left {
         display: flex;
-        justify-content: center;
+        flex-direction: column;
         background: lightgreen;
     }
 
     &__content {
-        width: 100%;
         display: flex;
-        justify-content: center;
+        flex-direction: column;
+        align-self: stretch;
         background: lightsalmon;
     }
 
     &__right {
         display: flex;
-        justify-content: center;
+        flex-direction: column;
         background: lightseagreen;
     }
 }

--- a/lib/components/Layout/PageLayout.scss
+++ b/lib/components/Layout/PageLayout.scss
@@ -3,7 +3,6 @@
     display: flex;
     gap: 1.5rem;
     padding-top: 1.5rem;
-    background: white;
 
     @include mobile {
         flex-direction: column;
@@ -12,19 +11,15 @@
     &__left {
         display: flex;
         flex-direction: column;
-        background: lightgreen;
     }
 
     &__content {
         display: flex;
         flex-direction: column;
-        align-self: stretch;
-        background: lightsalmon;
     }
 
     &__right {
         display: flex;
         flex-direction: column;
-        background: lightseagreen;
     }
 }

--- a/lib/components/Layout/index.tsx
+++ b/lib/components/Layout/index.tsx
@@ -1,15 +1,18 @@
 import React from 'react';
-import './layout.scss';
+import { useDevice } from '../../hooks/useDevice';
+import './PageLayout.scss';
 
 type TLayout = {
     left?: JSX.Element;
     right?: JSX.Element;
 };
 
-export const Layout: React.FC<React.PropsWithChildren<TLayout>> = ({children, left, right}) => {
+export const PageLayout: React.FC<React.PropsWithChildren<TLayout>> = ({children, left, right}) => {
+    const {isMobile} = useDevice();
+
     return <div className="layout">
-        <div className="layout__left">{left}</div>
-        <div className="layout__content">{children}</div>
-        <div className="layout__right">{right}</div>
+        {left && !isMobile && <div className="layout__left">{left}</div>}
+        {children && <div className="layout__content">{children}</div>}
+        {right && <div className="layout__right">{right}</div>}
     </div>
 }

--- a/lib/components/Layout/index.tsx
+++ b/lib/components/Layout/index.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import { useDevice } from '../../hooks/useDevice';
 import './PageLayout.scss';
 
-type TLayout = {
+type PageLayoutProps = {
     left?: JSX.Element;
     right?: JSX.Element;
 };
 
-export const PageLayout: React.FC<React.PropsWithChildren<TLayout>> = ({children, left, right}) => {
+export const PageLayout: React.FC<React.PropsWithChildren<PageLayoutProps>> = ({children, left, right}) => {
     const {isMobile} = useDevice();
 
     return <div className="layout">

--- a/lib/components/Layout/index.tsx
+++ b/lib/components/Layout/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import './layout.scss';
+
+type TLayout = {
+    left?: JSX.Element;
+    right?: JSX.Element;
+};
+
+export const Layout: React.FC<React.PropsWithChildren<TLayout>> = ({children, left, right}) => {
+    return <div className="layout">
+        <div className="layout__left">{left}</div>
+        <div className="layout__content">{children}</div>
+        <div className="layout__right">{right}</div>
+    </div>
+}

--- a/lib/components/Layout/layout.scss
+++ b/lib/components/Layout/layout.scss
@@ -1,0 +1,28 @@
+.layout {
+    width: 100%;
+    height: calc(100vh - 8.4rem);
+    display: flex;
+    justify-content: space-around;
+
+    padding: 1.5rem;
+    background: white;
+
+    &__left {
+        display: flex;
+        justify-content: center;
+        background: lightgreen;
+    }
+
+    &__content {
+        width: 100%;
+        display: flex;
+        justify-content: center;
+        background: lightsalmon;
+    }
+
+    &__right {
+        display: flex;
+        justify-content: center;
+        background: lightseagreen;
+    }
+}

--- a/lib/hooks/useDevice.ts
+++ b/lib/hooks/useDevice.ts
@@ -1,0 +1,15 @@
+import { useWindowSize } from "./useWindowSize";
+
+/** A custom hook to check for the client device and determine the layout to be rendered */
+export const useDevice = () => {
+    const { width } = useWindowSize();
+    const isMobile = width > 0 && width < 768;
+    const isTablet = width >= 768 && width < 1024;
+    const isDesktop = width >= 1024;
+
+    return {
+        isDesktop,
+        isMobile,
+        isTablet,
+    };
+};

--- a/lib/hooks/useWindowSize.ts
+++ b/lib/hooks/useWindowSize.ts
@@ -1,0 +1,23 @@
+// Code from: https://usehooks-ts.com/react-hook/use-window-size
+import { useState } from "react";
+import { useEventListener } from "./useEventListener";
+import { useIsomorphicLayoutEffect } from "./useIsomorphicLayoutEffect";
+
+/** Can be used to retrieve window dimensions with this React Hook which also works onResize. (Source: https://usehooks-ts.com/react-hook/use-window-size) */
+export const useWindowSize = () => {
+    const [windowSize, setWindowSize] = useState({
+        width: 0,
+        height: 0,
+    });
+    const handleSize = () => {
+        setWindowSize({
+            width: window.innerWidth,
+            height: window.innerHeight,
+        });
+    };
+    useEventListener("resize", handleSize);
+    useIsomorphicLayoutEffect(() => {
+        handleSize();
+    }, []);
+    return windowSize;
+};

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,7 +1,7 @@
 export { Button } from "./components/Button";
+export { Input } from "./components/Input";
 export { PageLayout } from "./components/Layout";
 export { Loader } from "./components/Loader";
-export { Text } from "./components/Text";
 export { Tab, Tabs } from "./components/Tabs";
+export { Text } from "./components/Text";
 export { Tooltip } from "./components/Tooltip";
-export { Input } from "./components/Input";

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,5 +1,5 @@
 export { Button } from "./components/Button";
-export { Layout } from "./components/Layout";
+export { PageLayout } from "./components/Layout";
 export { Loader } from "./components/Loader";
 export { Text } from "./components/Text";
 export { Tab, Tabs } from "./components/Tabs";

--- a/lib/main.ts
+++ b/lib/main.ts
@@ -1,5 +1,6 @@
-export { Loader } from "./components/Loader";
 export { Button } from "./components/Button";
+export { Layout } from "./components/Layout";
+export { Loader } from "./components/Loader";
 export { Text } from "./components/Text";
 export { Tab, Tabs } from "./components/Tabs";
 export { Tooltip } from "./components/Tooltip";


### PR DESCRIPTION
## Changes
#### `PageLayout` Component
- Layout component used in the cashier ( `<PageContainer />` ) and the account-settings pages.
- This is a three panel component which takes the content to be rendered as children and has left (optional) and right (optional) props to render items on the left and right side of the content.
- In responsive view, we do not render the left panel.

## Screenshots

https://github.com/deriv-com/ui/assets/125039206/a234a313-817c-4a96-b0a0-203a142913c8

