### PR TITLE
fix: imports from consuming projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": false,
   "version": "0.0.1-beta.8",
   "type": "module",
+  "main": "dist/main.js",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -3,16 +3,22 @@
   "private": false,
   "version": "0.0.1-beta.8",
   "type": "module",
-  "main": "dist/main.js",
   "files": [
     "dist"
   ],
+  "types": "./dist/main.d.ts",
+   "exports": {
+     ".": {
+       "import": "./dist/main.js",
+       "types": "./dist/main.d.ts"
+     }
+  },
   "sideEffects": [
     "**/*.css"
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc --p ./tsconfig-build.json && vite build",
+    "build": "tsc -p ./tsconfig-build.json && vite build",
     "prepublish": "npm run build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,13 +7,12 @@ import { libInjectCss } from 'vite-plugin-lib-inject-css'
 import dts from 'vite-plugin-dts'
 import sass from 'sass'
 
-
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     react(),
     libInjectCss(),
-    dts({ include: ['lib/components'] }),
+    dts({ include: ['lib'] }),
   ],
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
This fixes the imports so we can import components from the root, and still get the type definitions.

Example:

```tsx
import { Button } from '@deriv-com/ui'
```