### PR TITLE
Mark/Shayan/build: removed dist from import path

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,12 +7,19 @@
   "files": [
     "dist"
   ],
+  "types": "./dist/main.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/main.js",
+      "types": "./dist/main.d.ts"
+    }
+ },
   "sideEffects": [
     "**/*.css"
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc --p ./tsconfig-build.json && vite build",
+    "build": "tsc -p ./tsconfig-build.json && vite build",
     "prepublish": "npm run build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
   plugins: [
     react(),
     libInjectCss(),
-    dts({ include: ['lib/components'] }),
+    dts({ include: ['lib'] }),
   ],
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
This fixes the imports so we can import components from the root, and still get the type definitions.

Example:

`import { Button } from '@deriv-com/ui'`