### PR TITLE
[FEQ]Yaswanth/FEQ-1448-Added Text Area Component

### DIFF
--- a/lib/components/TextArea/TextArea.scss
+++ b/lib/components/TextArea/TextArea.scss
@@ -1,0 +1,64 @@
+.deriv-textarea {
+    position: relative;
+    width: 100%;
+
+    & textarea {
+        resize: none;
+        width: 100%;
+        height: 9.6rem;
+        border-radius: 0.4rem;
+        border: 1px solid #d6dadb;
+        outline: none;
+        padding: 1rem 1.6rem;
+        font-size: 1.4rem;
+
+        &:focus {
+            border: 1px solid #85acb0;
+        }
+
+        &::placeholder {
+            color: #999999;
+        }
+        &:focus + label span {
+            color: #85acb0;
+        }
+        &:focus + label,
+        &[data-has-value='true'] + label {
+            transform: translate(0, -1.4rem) scale(0.75);
+            background-color: #ffffff;
+        }
+        &:has(~ label)::placeholder {
+            color: transparent;
+        }
+    }
+
+    & label {
+        display: block;
+        position: absolute;
+        left: 1.6rem;
+        top: 1rem;
+        transition: all 0.2s ease;
+        transform-origin: left top;
+        text-overflow: ellipsis;
+        overflow: hidden;
+    }
+
+    &--error {
+        & textarea,
+        & textarea:focus {
+            border: 1px solid #ec3f3f;
+            & + label span {
+                color: #ec3f3f;
+            }
+        }
+    }
+
+    &__footer {
+        display: flex;
+        line-height: 1.5;
+
+        & span {
+            margin-left: auto;
+        }
+    }
+}

--- a/lib/components/TextArea/index.tsx
+++ b/lib/components/TextArea/index.tsx
@@ -1,0 +1,67 @@
+import React, { HtmlHTMLAttributes, useState } from 'react';
+import clsx from 'clsx';
+import { Text } from "../Text";
+import { TGenericSizes } from '../../types';
+import './TextArea.scss';
+
+type TTextAreaProps = HtmlHTMLAttributes<HTMLTextAreaElement> & {
+    hint?: string;
+    isInvalid?: boolean;
+    label?: string;
+    maxLength?: number;
+    onInputChange: React.ChangeEventHandler<HTMLTextAreaElement>;
+    placeholder?: string;
+    textSize:Extract<TGenericSizes, 'lg' | 'md' | 'sm'>;
+    shouldShowCounter?: boolean;
+    value?: string;
+};
+export const TextArea = ({
+    hint,
+    isInvalid = false,
+    label,
+    maxLength,
+    onInputChange,
+    placeholder,
+    textSize,
+    shouldShowCounter = false,
+    value,
+}: TTextAreaProps) => {
+    const [currentValue, setCurrentValue] = useState(value);
+
+    return (
+        <div
+            className={clsx('deriv-textarea', {
+                'deriv-textarea--error': isInvalid,
+            })}
+        >
+            <textarea
+                data-has-value={!!currentValue}
+                onChange={event => {
+                    setCurrentValue(event.target.value);
+                    onInputChange?.(event);
+                }}
+                placeholder={placeholder}
+                value={currentValue}
+            />
+            {label && (
+                <label>
+                    <Text color={isInvalid ? 'error' : 'less-prominent'} size={textSize}>
+                        {label}
+                    </Text>
+                </label>
+            )}
+            <div className='deriv-textarea__footer'>
+                {hint && (
+                    <Text as='p' color={isInvalid ? 'error' : 'less-prominent'} size={textSize}>
+                        {hint}
+                    </Text>
+                )}
+                {shouldShowCounter && (
+                    <Text color={isInvalid ? 'error' : 'less-prominent'} size={textSize}>
+                        {currentValue?.length || 0}/{maxLength}
+                    </Text>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/lib/components/TextArea/index.tsx
+++ b/lib/components/TextArea/index.tsx
@@ -1,10 +1,10 @@
-import React, { HtmlHTMLAttributes, useState } from 'react';
+import React, { HtmlHTMLAttributes} from 'react';
 import clsx from 'clsx';
 import { Text } from "../Text";
 import { TGenericSizes } from '../../types';
 import './TextArea.scss';
 
-type TTextAreaProps = HtmlHTMLAttributes<HTMLTextAreaElement> & {
+type TTextAreaProps = HtmlHTMLAttributes<HTMLTextAreaElement> &{
     hint?: string;
     isInvalid?: boolean;
     label?: string;
@@ -20,13 +20,11 @@ export const TextArea = ({
     isInvalid = false,
     label,
     maxLength,
-    onInputChange,
-    placeholder,
     textSize,
     shouldShowCounter = false,
     value,
+    ...rest
 }: TTextAreaProps) => {
-    const [currentValue, setCurrentValue] = useState(value);
 
     return (
         <div
@@ -35,13 +33,8 @@ export const TextArea = ({
             })}
         >
             <textarea
-                data-has-value={!!currentValue}
-                onChange={event => {
-                    setCurrentValue(event.target.value);
-                    onInputChange?.(event);
-                }}
-                placeholder={placeholder}
-                value={currentValue}
+                value={value}
+                {...rest}
             />
             {label && (
                 <label>
@@ -58,7 +51,7 @@ export const TextArea = ({
                 )}
                 {shouldShowCounter && (
                     <Text color={isInvalid ? 'error' : 'less-prominent'} size={textSize}>
-                        {currentValue?.length || 0}/{maxLength}
+                        {value?.length || 0}/{maxLength}
                     </Text>
                 )}
             </div>

--- a/lib/components/ToggleSwitch/index.tsx
+++ b/lib/components/ToggleSwitch/index.tsx
@@ -3,12 +3,12 @@ import clsx from "clsx";
 import './ToggleSwitch.scss';
 
 interface ToggleSwitchProps {
-    onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
+    onChange: (event: ChangeEvent<HTMLInputElement>) => void;
     value: boolean;
-    wrapperClassName: string;
-    className: string;
-    wrapperStyle: React.CSSProperties;
-    style: React.CSSProperties;
+    wrapperClassName?: string;
+    className?: string;
+    wrapperStyle?: React.CSSProperties;
+    style?: React.CSSProperties;
 }
 
 export const ToggleSwitch = forwardRef<HTMLInputElement, ToggleSwitchProps>(({ onChange, value, wrapperClassName, className, wrapperStyle, style }, ref) => (

--- a/lib/components/ToggleSwitch/index.tsx
+++ b/lib/components/ToggleSwitch/index.tsx
@@ -1,12 +1,13 @@
 import React, { ChangeEvent, forwardRef } from 'react';
 import clsx from "clsx";
+import { Input } from '../Input';
 import './ToggleSwitch.scss';
 
 interface ToggleSwitchProps {
     onChange: (event: ChangeEvent<HTMLInputElement>) => void;
     value: boolean;
-    wrapperClassName?: string;
-    className?: string;
+    wrapperClassName?: React.ComponentProps<typeof Input>['wrapperClassName'];
+    className?: React.ComponentProps<typeof Input>['className'];
     wrapperStyle?: React.CSSProperties;
     style?: React.CSSProperties;
 }

--- a/src/stories/TextArea.stories.ts
+++ b/src/stories/TextArea.stories.ts
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { TextArea } from "../../lib/components/TextArea"
+
+const meta = {
+    title: 'TextArea',
+    component: TextArea,
+    args: {
+        label: 'Description',
+        placeholder: 'Enter your text here',
+        hint: 'This is a hint for the user',
+        maxLength: 100,
+        onInputChange: action('Text changed'),
+    }
+} satisfies Meta<typeof TextArea>
+
+export default meta;
+type Story =StoryObj<typeof meta>
+
+export const Default:Story ={
+    args:{
+        label: 'Description',
+        placeholder: 'Enter your text here',
+        hint: 'This is a hint for the user',
+        maxLength: 100,
+        onInputChange: action('Text changed'),
+        textSize:"sm",
+    }
+}
+
+export const WithError:Story = {
+    args:{
+        label: 'Description',
+        placeholder: 'Enter your text here',
+        hint: 'This is an error hint',
+        maxLength: 100,
+        isInvalid: true,
+        onInputChange: action('Text changed'),
+        textSize:"sm"
+    }
+}
+
+export const WithCounter:Story ={
+    args:{
+        label: 'Description',
+        placeholder: 'Enter your text here',
+        hint: 'This is a counter hint',
+        maxLength: 100,
+        shouldShowCounter: true,
+        onInputChange: action('Text changed'),
+        textSize:"sm"
+    }
+}
+
+export const WithErrorAndCounter:Story ={
+    args:{
+        label: 'Description',
+        placeholder: 'Enter your text here',
+        hint: 'This is an error and counter hint',
+        maxLength: 100,
+        isInvalid: true,
+        shouldShowCounter: true,
+        onInputChange: action('Text changed'),
+        textSize:"sm"
+    }
+}


### PR DESCRIPTION
Added a textarea component within the deriv/ui package, making it accessible for use across various packages by importing it directly from this library.
<img width="1198" alt="Screenshot 2024-02-02 at 4 49 56 PM" src="https://github.com/deriv-com/ui/assets/121096908/6ec18fbb-8a0f-4432-985c-4809eaf28550">
