### PR TITLE
[FEQ] aum/FEQ-1696/page-layout-remove-padding-gap

### DIFF
--- a/lib/components/PageLayout/PageLayout.scss
+++ b/lib/components/PageLayout/PageLayout.scss
@@ -1,8 +1,6 @@
 .derivs-page-layout {
     width: 100%;
     display: flex;
-    gap: 1.5rem;
-    padding-top: 1.5rem;
 
     @include mobile {
         flex-direction: column;


### PR DESCRIPTION
Changes:

Removed the padding-top for the PageLayout and also the gap between the sidebar and content section.

https://github.com/deriv-com/ui/assets/125039206/cb1c557f-c894-4599-b66b-d14c8c9a12d2

