### PR TITLE
[FEQ] Aum/FEQ-1699/ActionScreen-component

### DIFF
--- a/lib/components/ActionScreen/ActionScreen.scss
+++ b/lib/components/ActionScreen/ActionScreen.scss
@@ -1,0 +1,12 @@
+.derivs-action-screen {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 2.4rem;
+
+    &__info {
+        display: flex;
+        flex-direction: column;
+        gap: 0.8rem;
+    }
+}

--- a/lib/components/ActionScreen/index.tsx
+++ b/lib/components/ActionScreen/index.tsx
@@ -1,48 +1,57 @@
-import React, { ComponentProps, isValidElement, PropsWithChildren,  ReactNode } from 'react';
-import { Text } from '../Text';
-import './ActionScreen.scss';
+import React, {
+    ComponentProps,
+    isValidElement,
+    PropsWithChildren,
+    ReactNode,
+} from "react";
+import { Text } from "../Text";
+import "./ActionScreen.scss";
 
 type TProps = {
-    children?: ReactNode,
+    actionButtons?: JSX.Element;
+    children?: ReactNode;
     description?: ReactNode;
-    descriptionSize?: ComponentProps<typeof Text>['size'];
+    descriptionSize?: ComponentProps<typeof Text>["size"];
     icon?: ReactNode;
-    renderButtons?: () => ReactNode;
     title?: ReactNode;
-    titleSize?: ComponentProps<typeof Text>['size'];
+    titleSize?: ComponentProps<typeof Text>["size"];
 };
 
 /**
  * Generic component to display status / action screen / final screen.
- * (`Icon`, `Title`, `Description`, `CTA`)
+ * @param {TProps.actionButtons} actionButtons Button / group of buttons for CTA.
+ * @param {TProps.description} description Description content to be displayed as the description.
+ * @param {TProps.descriptionSize} descriptionSize Font-size of the description.
+ * @param {TProps.title} title Title content to be displayed.
+ * @param {TProps.titleSize} titleSize Font-size of the title.
  */
 export const ActionScreen: React.FC<PropsWithChildren<TProps>> = ({
+    actionButtons,
     children,
     description,
-    descriptionSize = 'md',
+    descriptionSize = "md",
     icon,
-    renderButtons,
     title,
-    titleSize = 'md',
+    titleSize = "md",
 }) => {
     return (
-        <div className='derivs-action-screen'>
+        <div className="derivs-action-screen">
             {icon}
-            <div className='derivs-action-screen__info'>
+            <div className="derivs-action-screen__info">
                 {title && (
-                    <Text align='center' size={titleSize} weight='bold'>
+                    <Text align="center" size={titleSize} weight="bold">
                         {title}
                     </Text>
                 )}
                 {isValidElement(description) ? (
                     description
                 ) : (
-                    <Text align='center' size={descriptionSize}>
+                    <Text align="center" size={descriptionSize}>
                         {description}
                     </Text>
                 )}
             </div>
-            {renderButtons?.()}
+            {actionButtons}
             {children}
         </div>
     );

--- a/lib/components/ActionScreen/index.tsx
+++ b/lib/components/ActionScreen/index.tsx
@@ -1,0 +1,49 @@
+import React, { ComponentProps, isValidElement, PropsWithChildren,  ReactNode } from 'react';
+import { Text } from '../Text';
+import './ActionScreen.scss';
+
+type TProps = {
+    description: ReactNode;
+    descriptionSize?: ComponentProps<typeof Text>['size'];
+    icon?: ReactNode;
+    renderButtons?: () => ReactNode;
+    title?: ReactNode;
+    titleSize?: ComponentProps<typeof Text>['size'];
+};
+
+/**
+ * Generic component to display status / action screen / final screen
+ * As its common and repeated in many places,
+ * at the moment of writing this, there are already 3 different patterns use to display ex
+ */
+export const ActionScreen: React.FC<PropsWithChildren<TProps>> = ({
+    children,
+    description,
+    descriptionSize = 'md',
+    icon,
+    renderButtons,
+    title,
+    titleSize = 'md',
+}) => {
+    return (
+        <div className='derivs-action-screen'>
+            {icon}
+            <div className='derivs-action-screen__info'>
+                {title && (
+                    <Text align='center' size={titleSize} weight='bold'>
+                        {title}
+                    </Text>
+                )}
+                {isValidElement(description) ? (
+                    description
+                ) : (
+                    <Text align='center' size={descriptionSize}>
+                        {description}
+                    </Text>
+                )}
+            </div>
+            {renderButtons?.()}
+            {children}
+        </div>
+    );
+};

--- a/lib/components/ActionScreen/index.tsx
+++ b/lib/components/ActionScreen/index.tsx
@@ -1,15 +1,9 @@
-import React, {
-    ComponentProps,
-    isValidElement,
-    PropsWithChildren,
-    ReactNode,
-} from "react";
+import React, { ComponentProps, isValidElement, ReactNode } from "react";
 import { Text } from "../Text";
 import "./ActionScreen.scss";
 
 type TProps = {
     actionButtons?: JSX.Element;
-    children?: ReactNode;
     description?: ReactNode;
     descriptionSize?: ComponentProps<typeof Text>["size"];
     icon?: ReactNode;
@@ -25,9 +19,8 @@ type TProps = {
  * @param {TProps.title} title Title content to be displayed.
  * @param {TProps.titleSize} titleSize Font-size of the title.
  */
-export const ActionScreen: React.FC<PropsWithChildren<TProps>> = ({
+export const ActionScreen: React.FC<TProps> = ({
     actionButtons,
-    children,
     description,
     descriptionSize = "md",
     icon,
@@ -52,7 +45,6 @@ export const ActionScreen: React.FC<PropsWithChildren<TProps>> = ({
                 )}
             </div>
             {actionButtons}
-            {children}
         </div>
     );
 };

--- a/lib/components/ActionScreen/index.tsx
+++ b/lib/components/ActionScreen/index.tsx
@@ -3,7 +3,8 @@ import { Text } from '../Text';
 import './ActionScreen.scss';
 
 type TProps = {
-    description: ReactNode;
+    children?: ReactNode,
+    description?: ReactNode;
     descriptionSize?: ComponentProps<typeof Text>['size'];
     icon?: ReactNode;
     renderButtons?: () => ReactNode;
@@ -12,9 +13,8 @@ type TProps = {
 };
 
 /**
- * Generic component to display status / action screen / final screen
- * As its common and repeated in many places,
- * at the moment of writing this, there are already 3 different patterns use to display ex
+ * Generic component to display status / action screen / final screen.
+ * (`Icon`, `Title`, `Description`, `CTA`)
  */
 export const ActionScreen: React.FC<PropsWithChildren<TProps>> = ({
     children,

--- a/src/stories/ActionScreen.stories.tsx
+++ b/src/stories/ActionScreen.stories.tsx
@@ -7,50 +7,69 @@ const meta = {
     title: "Components/ActionScreen",
     component: ActionScreen,
     args: {
+        actionButtons: <Button>CTA Button</Button>,
         children: (
             <div>This is a child passed to the ActionScreen component</div>
         ),
-        description: "This is the ActionScreen component from the deriv-com/ui library.",
-        descriptionSize: 'md',
-        icon: (<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 72 72" role="img" id="selected_downloadable_icon_id" height="120px" width="120px"><path fill="#FF444F" d="M0 28C0 12.536 12.536 0 28 0h16c15.464 0 28 12.536 28 28v16c0 15.464-12.536 28-28 28H28C12.536 72 0 59.464 0 44z"></path><path fill="#fff" d="m45.167 14.917-2.321 13.166h-8.06c-7.518 0-14.684 6.091-16.012 13.61l-.563 3.2c-1.322 7.518 3.695 13.61 11.213 13.61h6.722c5.48 0 10.7-4.436 11.664-9.916L54 13.497zM39.45 47.346c-.296 1.692-1.82 3.07-3.513 3.07h-4.084c-3.38 0-5.64-2.743-5.047-6.128l.352-1.996c.6-3.38 3.824-6.128 7.203-6.128h7.06z"></path></svg>),
-        renderButtons: () => <Button>CTA Button</Button>,
+        description:
+            "This is the ActionScreen component from the deriv-com/ui library.",
+        descriptionSize: "md",
+        icon: (
+            <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 72 72"
+                role="img"
+                id="selected_downloadable_icon_id"
+                height="120px"
+                width="120px"
+            >
+                <path
+                    fill="#FF444F"
+                    d="M0 28C0 12.536 12.536 0 28 0h16c15.464 0 28 12.536 28 28v16c0 15.464-12.536 28-28 28H28C12.536 72 0 59.464 0 44z"
+                ></path>
+                <path
+                    fill="#fff"
+                    d="m45.167 14.917-2.321 13.166h-8.06c-7.518 0-14.684 6.091-16.012 13.61l-.563 3.2c-1.322 7.518 3.695 13.61 11.213 13.61h6.722c5.48 0 10.7-4.436 11.664-9.916L54 13.497zM39.45 47.346c-.296 1.692-1.82 3.07-3.513 3.07h-4.084c-3.38 0-5.64-2.743-5.047-6.128l.352-1.996c.6-3.38 3.824-6.128 7.203-6.128h7.06z"
+                ></path>
+            </svg>
+        ),
         title: "Welcome to Deriv's UI Library",
     },
     argTypes: {
         children: {
             control: false,
-            description: 'Children can be passed to this component.',
+            description: "Children can be passed to this component.",
         },
         description: {
             control: false,
-            description: 'Contains the description to be shown.',
+            description: "Contains the description to be shown.",
         },
         descriptionSize: {
-            description: 'Sets the description text size.',  
+            description: "Sets the description text size.",
         },
         icon: {
             control: false,
-            description: 'Can be used for rendering icons.'
+            description: "Can be used for rendering icons.",
         },
-        renderButtons: {
+        actionButtons: {
             control: false,
-            description: 'A render prop for rendering CTA buttons.'
+            description:
+                "A prop which can be passed with a single button or div containing a group of buttons for CTA.",
         },
         title: {
             control: false,
-            description: 'Contains the title to be shown.'
+            description: "Contains the title to be shown.",
         },
         titleSize: {
-            description: 'Sets the title text size.',   
+            description: "Sets the title text size.",
         },
     },
     parameters: {
         layout: "centered",
     },
     tags: ["autodocs"],
-    render: (args) => (
-        <ActionScreen {...args}></ActionScreen>
-    ),
+    render: (args) => <ActionScreen {...args}></ActionScreen>,
 } satisfies Meta<typeof ActionScreen>;
 
 export default meta;
@@ -58,5 +77,5 @@ type Story = StoryObj<typeof meta>;
 
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const Default: Story = {
-    name: "PageLayout",
+    name: "ActionScreen",
 };

--- a/src/stories/ActionScreen.stories.tsx
+++ b/src/stories/ActionScreen.stories.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { ActionScreen } from "../../lib/components/ActionScreen";
+import { Button } from "../../lib/main";
+
+const meta = {
+    title: "Components/ActionScreen",
+    component: ActionScreen,
+    args: {
+        children: (
+            <div>This is a child passed to the ActionScreen component</div>
+        ),
+        description: "This is the ActionScreen component from the deriv-com/ui library.",
+        descriptionSize: 'md',
+        icon: (<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 72 72" role="img" id="selected_downloadable_icon_id" height="120px" width="120px"><path fill="#FF444F" d="M0 28C0 12.536 12.536 0 28 0h16c15.464 0 28 12.536 28 28v16c0 15.464-12.536 28-28 28H28C12.536 72 0 59.464 0 44z"></path><path fill="#fff" d="m45.167 14.917-2.321 13.166h-8.06c-7.518 0-14.684 6.091-16.012 13.61l-.563 3.2c-1.322 7.518 3.695 13.61 11.213 13.61h6.722c5.48 0 10.7-4.436 11.664-9.916L54 13.497zM39.45 47.346c-.296 1.692-1.82 3.07-3.513 3.07h-4.084c-3.38 0-5.64-2.743-5.047-6.128l.352-1.996c.6-3.38 3.824-6.128 7.203-6.128h7.06z"></path></svg>),
+        renderButtons: () => <Button>CTA Button</Button>,
+        title: "Welcome to Deriv's UI Library",
+    },
+    argTypes: {
+        children: {
+            control: false,
+            description: 'Children can be passed to this component.',
+        },
+        description: {
+            control: false,
+            description: 'Contains the description to be shown.',
+        },
+        descriptionSize: {
+            description: 'Sets the description text size.',  
+        },
+        icon: {
+            control: false,
+            description: 'Can be used for rendering icons.'
+        },
+        renderButtons: {
+            control: false,
+            description: 'A render prop for rendering CTA buttons.'
+        },
+        title: {
+            control: false,
+            description: 'Contains the title to be shown.'
+        },
+        titleSize: {
+            description: 'Sets the title text size.',   
+        },
+    },
+    parameters: {
+        layout: "centered",
+    },
+    tags: ["autodocs"],
+    render: (args) => (
+        <ActionScreen {...args}></ActionScreen>
+    ),
+} satisfies Meta<typeof ActionScreen>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+export const Default: Story = {
+    name: "PageLayout",
+};

--- a/src/stories/ActionScreen.stories.tsx
+++ b/src/stories/ActionScreen.stories.tsx
@@ -8,9 +8,6 @@ const meta = {
     component: ActionScreen,
     args: {
         actionButtons: <Button>CTA Button</Button>,
-        children: (
-            <div>This is a child passed to the ActionScreen component</div>
-        ),
         description:
             "This is the ActionScreen component from the deriv-com/ui library.",
         descriptionSize: "md",
@@ -37,10 +34,6 @@ const meta = {
         title: "Welcome to Deriv's UI Library",
     },
     argTypes: {
-        children: {
-            control: false,
-            description: "Children can be passed to this component.",
-        },
         description: {
             control: false,
             description: "Contains the description to be shown.",


### PR DESCRIPTION
ActionScreen is a reusable component which is used in the cashier and accounts-settings pages for showing screens with design containing the following layout:
```
                                              icon
                                              title
                                           Description
                                               CTA (optional)
```
![image](https://github.com/deriv-com/ui/assets/125039206/50eb6685-e4d4-4abd-b615-518095efa201)