### PR TITLE
Aizad/ Fix Checkbox id returning errors inside of deriv.app

### DIFF
--- a/lib/components/Checkbox/index.tsx
+++ b/lib/components/Checkbox/index.tsx
@@ -1,9 +1,13 @@
-import { ComponentProps, ReactNode, Ref, forwardRef, useId } from "react";
+import { ComponentProps, ReactNode, Ref, forwardRef } from "react";
 import clsx from "clsx";
 import "./Checkbox.scss";
 
 interface CheckboxProps
-  extends Omit<ComponentProps<"input">, "placeholder" | "defaultChecked"> {
+  extends Omit<
+    ComponentProps<"input">,
+    "placeholder" | "defaultChecked" | "name"
+  > {
+  name: string;
   error?: boolean;
   label?: ReactNode;
   labelClassName?: string;
@@ -20,17 +24,16 @@ export const Checkbox = forwardRef(
       label,
       labelClassName,
       wrapperClassName,
+      name,
       ...rest
     }: CheckboxProps,
     ref: Ref<HTMLInputElement>
   ) => {
-    const id = useId();
-
     return (
       <div className={clsx("deriv-checkbox", wrapperClassName)}>
         <div className="deriv-checkbox__wrapper">
           <input
-            id={rest.id ?? id}
+            id={rest.id ?? name}
             className={clsx(
               "deriv-checkbox__box",
               {
@@ -44,6 +47,7 @@ export const Checkbox = forwardRef(
             checked={!disabled && checked}
             disabled={disabled}
             ref={ref}
+            name={name}
             {...rest}
           />
         </div>
@@ -56,7 +60,7 @@ export const Checkbox = forwardRef(
             },
             labelClassName
           )}
-          htmlFor={rest.id ?? id}
+          htmlFor={rest.id ?? name}
         >
           {label}
         </label>

--- a/src/stories/Checkbox.stories.tsx
+++ b/src/stories/Checkbox.stories.tsx
@@ -14,9 +14,15 @@ const meta = {
     label: "Get updates about Deriv products, services and events.",
     onChange: () => {},
     wrapperClassName: "",
+    name: "example-checkbox",
     error: false,
   },
   argTypes: {
+    name: {
+      control: {
+        type: "text",
+      },
+    },
     wrapperClassName: {
       control: {
         disable: true,
@@ -63,6 +69,7 @@ export const Default: Story = {
   args: {
     checked: false,
     onChange: () => {},
+    name: "example-checkbox",
     label: "Get updates about Deriv products, services and events.",
   },
   render: (args) => {


### PR DESCRIPTION
- remove useId() from Checkbox component.
- make `name` as a required prop.
- use `name` instead as a fallback for the `id`.
- updated storybook.

![image](https://github.com/deriv-com/ui/assets/103104395/b8640ebd-b4eb-405f-bd52-5d46ac086df0)
