### PR TITLE
fix: fixed oveflow issue in modal body

### DIFF
--- a/lib/components/Modal/Modal.scss
+++ b/lib/components/Modal/Modal.scss
@@ -33,7 +33,7 @@
 
 .deriv-modal__body {
     flex: 1;
-    padding:8px 24px;
+    overflow: auto;
 }
 
 .deriv-modal__footer {


### PR DESCRIPTION
changes:
- removed the default padding from modal body to let the consumer apply it if needed
- added `overflow: auto` to modal body wrapper