### PR TITLE
fix: added new classname to modal header

### DIFF
--- a/lib/components/Modal/Modal.scss
+++ b/lib/components/Modal/Modal.scss
@@ -20,9 +20,6 @@
         &--no-border {
             border-bottom: none;
         }
-        &--justify-end{
-            justify-content: flex-end;
-        }
     }
     &__title {
         font-size: 20px;
@@ -31,6 +28,7 @@
     &__close-icon {
         cursor: pointer;
         margin: 8px;
+        margin-left: auto;
     }
 }
 

--- a/lib/components/Modal/Modal.scss
+++ b/lib/components/Modal/Modal.scss
@@ -20,6 +20,9 @@
         &--no-border {
             border-bottom: none;
         }
+        &--justify-end{
+            justify-content: flex-end;
+        }
     }
     &__title {
         font-size: 20px;

--- a/lib/components/Modal/ModalHeader.tsx
+++ b/lib/components/Modal/ModalHeader.tsx
@@ -14,7 +14,6 @@ export const ModalHeader = ({ children, hideCloseIcon, className, onRequestClose
     return (
         <div className={clsx('deriv-modal__header', {
             'deriv-modal__header--no-border': hideBorder,
-            'deriv-modal__header--justify-end': !children,
         }, className)} {...rest}>
             {children}
             {!hideCloseIcon && <CloseIcon data-testid="dt-close-icon" onClick={onRequestClose} className="deriv-modal__close-icon" />}

--- a/lib/components/Modal/ModalHeader.tsx
+++ b/lib/components/Modal/ModalHeader.tsx
@@ -14,6 +14,7 @@ export const ModalHeader = ({ children, hideCloseIcon, className, onRequestClose
     return (
         <div className={clsx('deriv-modal__header', {
             'deriv-modal__header--no-border': hideBorder,
+            'deriv-modal__header--justify-end': !children,
         }, className)} {...rest}>
             {children}
             {!hideCloseIcon && <CloseIcon data-testid="dt-close-icon" onClick={onRequestClose} className="deriv-modal__close-icon" />}


### PR DESCRIPTION
## the issue:
- when no title is passed the close icon inside modal header was left aligned but we expected that it be right

## changes:
- added a new classname and check if there is no children passed to the header, then I'm applying `flex-end` for the `justify-content`

## screenshots:
before: 
![image](https://github.com/deriv-com/ui/assets/100833613/e615a9be-864a-4673-8cd0-332e6e7dc26c)

after:
![image](https://github.com/deriv-com/ui/assets/100833613/7af80577-b89f-4dcb-b0cb-5a9e768b1338)

