### PR TITLE
chore: use generated github_action token

### DIFF
--- a/.github/workflows/publish_npm_package.yml
+++ b/.github/workflows/publish_npm_package.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
         with:
           fetch-depth: 0
-          token: ${{ secrets.CI_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Node.js
         uses: actions/setup-node@b39b52d1213e96004bfcb1c61a8a6fa8ab84f3e8
         with:


### PR DESCRIPTION
Instead of using a PAT for the ci/cd jobs, we should be able to use the generated GITHUB_TOKEN instead.