### PR TITLE
likhith/fix: button type in accordion component

### DIFF
--- a/src/components/Accordion/index.tsx
+++ b/src/components/Accordion/index.tsx
@@ -50,6 +50,7 @@ export const Accordion = ({
                 })}
                 onClick={toggleAccordion}
                 aria-expanded={active}
+                type="button"
             >
                 {typeof title === "string" ? <p>{title}</p> : title}
                 <img

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -20,7 +20,7 @@ type TProps = HtmlHTMLAttributes<HTMLInputElement> & {
     icon?: React.ReactNode;
     isRequired?: boolean;
     isFullWidth?: boolean;
-    label?: InputProps['label'];
+    label?: InputProps["label"];
     list: {
         text?: React.ReactNode;
         value?: string;
@@ -123,6 +123,7 @@ export const Dropdown = ({
                 className={clsx("deriv-dropdown__button", {
                     "deriv-dropdown__button--active": isOpen,
                 })}
+                type="button"
             >
                 {dropdownIcon}
             </button>
@@ -157,14 +158,17 @@ export const Dropdown = ({
                     {...rest}
                 />
             </div>
-            <ul className={clsx(
-                'deriv-dropdown__items',
-                `deriv-dropdown__items--${listHeight}`,
-                {
-                    'deriv-dropdown__items--full': isFullWidth,
-             }
-            )} {...getMenuProps()}>
-                {isOpen && (
+            <ul
+                className={clsx(
+                    "deriv-dropdown__items",
+                    `deriv-dropdown__items--${listHeight}`,
+                    {
+                        "deriv-dropdown__items--full": isFullWidth,
+                    },
+                )}
+                {...getMenuProps()}
+            >
+                {isOpen &&
                     items.map((item, index) => (
                         <li
                             className={clsx("deriv-dropdown__item", {
@@ -184,9 +188,7 @@ export const Dropdown = ({
                                 {item.text}
                             </Text>
                         </li>
-                    ))
-                )
-                }
+                    ))}
             </ul>
         </div>
     );

--- a/src/components/PasswordInput/index.tsx
+++ b/src/components/PasswordInput/index.tsx
@@ -37,11 +37,9 @@ export const validatePassword = (password: string, customErrorMessage = "") => {
         errorMessage = passwordErrorMessage.invalidLength;
     } else if (!isPasswordValid(password)) {
         errorMessage = passwordErrorMessage.missingCharacter;
-    }
-    else if (customErrorMessage) {
+    } else if (customErrorMessage) {
         errorMessage = customErrorMessage;
-    }
-    else {
+    } else {
         errorMessage = warningMessages[feedback.warning as passwordKeys] ?? "";
     }
 
@@ -102,7 +100,8 @@ export const PasswordInput = ({
     }, [customErrorMessage]);
     const [isTouched, setIsTouched] = useState(false);
     const [showPassword, setShowPassword] = useState(false);
-    const [backendErrorMessage, setBackendErrorMessage] = useState(customErrorMessage);
+    const [backendErrorMessage, setBackendErrorMessage] =
+        useState(customErrorMessage);
 
     const { errorMessage, score } = useMemo(
         () => validatePassword(value as string, backendErrorMessage),
@@ -151,6 +150,7 @@ export const PasswordInput = ({
                     <button
                         className="deriv-password__icon"
                         onClick={() => setShowPassword(!showPassword)}
+                        type="button"
                     >
                         {showPassword ? <EyeIcon /> : <EyeIconSlash />}
                     </button>

--- a/src/components/SideNote/index.tsx
+++ b/src/components/SideNote/index.tsx
@@ -43,7 +43,13 @@ export const SideNote = ({
 }: PropsWithChildren<SideNoteProps>) => (
     <div className={clsx("deriv-side-note", className)} {...props}>
         {title && (
-            <Text data-testid="dt_deriv-side-note-title" className={clsx("deriv-side-note__title", titleClassName)} size={titleSize} align="left" weight="bold">
+            <Text
+                data-testid="dt_deriv-side-note-title"
+                className={clsx("deriv-side-note__title", titleClassName)}
+                size={titleSize}
+                align="left"
+                weight="bold"
+            >
                 {title}
             </Text>
         )}
@@ -54,6 +60,7 @@ export const SideNote = ({
             <button
                 className={clsx("deriv-side-note__action", actionClassName)}
                 onClick={actionClick}
+                type="button"
             >
                 <Text color="red" size="xs">
                     {actionLabel}

--- a/src/components/Tabs/TabTitle.tsx
+++ b/src/components/Tabs/TabTitle.tsx
@@ -47,6 +47,7 @@ const TabTitle = ({
                 },
                 className,
             )}
+            type="button"
             onClick={() => handleOnClick(title)}
         >
             {icon}


### PR DESCRIPTION
When Accordion component is used inside a form, due to event bubbling the form submit handler gets invoked. This is because for most browsers the default type of button is `submit`.

The issue is seen in Accordion and SideNote component

The button type is set to `button` to avoid this