### PR TITLE
Ameerul / Fix useFetchMore loadMore data issues on scroll

### DIFF
--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -14,7 +14,6 @@ type TProps<T> = {
     columns?: ColumnDef<T>[];
     data: T[];
     emptyDataMessage?: string;
-    isFetching: boolean;
     loadMoreFunction: () => void;
     renderHeader?: (data: string) => JSX.Element;
     rowRender: (data: T) => JSX.Element;
@@ -25,7 +24,6 @@ export const Table = <T,>({
     columns = [],
     data,
     emptyDataMessage,
-    isFetching,
     loadMoreFunction,
     renderHeader = () => <div />,
     rowRender,
@@ -45,7 +43,6 @@ export const Table = <T,>({
     const { fetchMoreOnBottomReached } = useFetchMore({
         loadMore: loadMoreFunction,
         ref: tableContainerRef,
-        isFetching,
     });
 
     return (

--- a/stories/Table.stories.tsx
+++ b/stories/Table.stories.tsx
@@ -62,7 +62,6 @@ const meta: Meta<typeof Table> = {
     args: {
         columns: [],
         data: [],
-        isFetching: false,
         loadMoreFunction: () => {},
         renderHeader: () => <div />,
         rowRender: () => <div />,
@@ -79,7 +78,6 @@ export const Default: Story = {
     args: {
         columns: [],
         data: data,
-        isFetching: false,
         loadMoreFunction: () => {},
         renderHeader: () => <div />,
         rowRender: (item) => rowRender(item as Record<string, string>),
@@ -92,7 +90,6 @@ export const WithHeader: Story = {
     args: {
         columns,
         data: data,
-        isFetching: false,
         loadMoreFunction: () => {},
         renderHeader: (data) => <span>{data}</span>,
         rowRender: (item) => rowRender(item as Record<string, string>),


### PR DESCRIPTION
- There were issues with the data being infinitely fetched because it had assumed the user had reached the end of the scrollbar height. Thus I had fixed it here in this PR