### PR TITLE
[FEQ] Jim/FEQ-2472/add border width prop and variants

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -215,6 +215,9 @@ $black-outline-hover: rgba(0, 0, 0, 0.08);
         &--md {
             border-width: 2px;
         }
+        &--lg {
+            border-width: 3px;
+        }
     }
 
 }

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -205,4 +205,16 @@ $black-outline-hover: rgba(0, 0, 0, 0.08);
         }
     }
 
+    &__border-width {
+        &--none {
+            border-width: 0;
+        }
+        &--sm {
+            border-width: 1px;
+        }
+        &--md {
+            border-width: 2px;
+        }
+    }
+
 }

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -68,7 +68,7 @@ const BorderWidth = {
 } as const;
 
 export const Button = ({
-    borderWidth = 'sm',
+    borderWidth = 'md',
     className,
     color = "primary",
     icon,

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -7,7 +7,7 @@ import "./Button.scss";
 
 type TVariant = "contained" | "ghost" | "outlined";
 type TColor = "black" | "primary-light" | "primary" | "white";
-type TBorderWidth = Extract<TGenericSizes, 'md' | 'sm'> | 'none';
+type TBorderWidth = Extract<TGenericSizes, 'md' | 'sm' | 'lg'> | 'none';
 
 interface ButtonProps extends ComponentProps<"button"> {
     borderWidth?: TBorderWidth;
@@ -61,9 +61,10 @@ const LoaderColor = {
 } as const;
 
 const BorderWidth = {
-    md: "deriv-button__border-width--md",
-    sm: "deriv-button__border-width--sm",
     none: "deriv-button__border-width--none",
+    sm: "deriv-button__border-width--sm",
+    md: "deriv-button__border-width--md",
+    lg: "deriv-button__border-width--lg",
 } as const;
 
 export const Button = ({

--- a/src/components/Button/index.tsx
+++ b/src/components/Button/index.tsx
@@ -7,8 +7,10 @@ import "./Button.scss";
 
 type TVariant = "contained" | "ghost" | "outlined";
 type TColor = "black" | "primary-light" | "primary" | "white";
+type TBorderWidth = Extract<TGenericSizes, 'md' | 'sm'> | 'none';
 
 interface ButtonProps extends ComponentProps<"button"> {
+    borderWidth?: TBorderWidth;
     color?: TColor;
     icon?: ReactElement | ReactNode;
     isFullWidth?: boolean;
@@ -58,7 +60,14 @@ const LoaderColor = {
     white: "#85ACB0",
 } as const;
 
+const BorderWidth = {
+    md: "deriv-button__border-width--md",
+    sm: "deriv-button__border-width--sm",
+    none: "deriv-button__border-width--none",
+} as const;
+
 export const Button = ({
+    borderWidth = 'sm',
     className,
     color = "primary",
     icon,
@@ -80,6 +89,7 @@ export const Button = ({
                 ButtonColor[color],
                 ButtonSize[size],
                 ButtonRounded[rounded],
+                BorderWidth[borderWidth],
                 {
                     "deriv-button__full-width": isFullWidth,
                     "deriv-button__hover--disabled": hideHoverStyles,

--- a/stories/Button.stories.ts
+++ b/stories/Button.stories.ts
@@ -9,6 +9,7 @@ const meta = {
     },
     tags: ["autodocs"],
     args: {
+        borderWidth: "sm",
         variant: "contained",
         children: "Click Me!",
         color: "primary",
@@ -23,6 +24,10 @@ const meta = {
     },
 
     argTypes: {
+        borderWidth: {
+            options: ["none", "sm", "md"],
+            control: { type: "radio" },
+        },
         variant: {
             options: ["contained", "outlined", "ghost"],
             control: { type: "radio" },

--- a/stories/Button.stories.ts
+++ b/stories/Button.stories.ts
@@ -9,7 +9,7 @@ const meta = {
     },
     tags: ["autodocs"],
     args: {
-        borderWidth: "sm",
+        borderWidth: "md",
         variant: "contained",
         children: "Click Me!",
         color: "primary",
@@ -25,7 +25,7 @@ const meta = {
 
     argTypes: {
         borderWidth: {
-            options: ["none", "sm", "md"],
+            options: ["none", "sm", "md", "lg"],
             control: { type: "radio" },
         },
         variant: {


### PR DESCRIPTION
## Changes
- Added `borderWidth` prop and it's variants (`none`, `sm`, `md`)

## Screenshots
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/5c59742d-0b6f-4192-a06e-3d2bc4d93bb4">
