### PR TITLE
style: fixed style issues for language switcher modal

### DIFF
--- a/src/components/AppLayout/LanguagesSwitcher/LanguagesModal.scss
+++ b/src/components/AppLayout/LanguagesSwitcher/LanguagesModal.scss
@@ -6,14 +6,14 @@
         align-items: center;
         grid-template-columns: repeat(4, 1fr);
         grid-gap: 1rem;
-        margin: 16px 0;
+        margin: 16px auto;
         &-button {
-            height: 88px;
+            height: auto;
             width: 133px;
             display: flex;
             align-items: center;
             flex-direction: column;
-            padding: 8px;
+            padding: 12px 8px;
             &-selected {
                 border-radius: 4px;
                 border: 1px solid var(--brand-blue, #85acb0);


### PR DESCRIPTION
## changes:
- changed language items height to `auto` and added padding-y 
- changed the margin-x to `auto` for the modal container 