### PR TITLE
[FEQ] Jim/FEQ-2508/Add colours to prop type

### DIFF
--- a/src/components/Text/index.tsx
+++ b/src/components/Text/index.tsx
@@ -13,7 +13,10 @@ type TextColors =
     | "red"
     | "blue"
     | "green"
-    | "white";
+    | "white"
+    | "black"
+    | "orange"
+    | "system-dark-2-general-text";
 
 type TGenericSizes =
     | "2xl"


### PR DESCRIPTION
Added colours `black`, `orange`, and `system-dark-2-general-text` to the `TextColors` prop type