### PR TITLE
Ameerul / Fix multiple api calls when scrolling table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@popperjs/core": "^2.11.8",
                 "@types/react-modal": "^3.16.3",
+                "lodash.debounce": "^4.0.8",
                 "react-popper": "^2.3.0"
             },
             "devDependencies": {
@@ -15802,8 +15803,7 @@
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-            "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
-            "dev": true
+            "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
         },
         "node_modules/lodash.escaperegexp": {
             "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "dependencies": {
         "@popperjs/core": "^2.11.8",
         "@types/react-modal": "^3.16.3",
+        "lodash.debounce": "^4.0.8",
         "react-popper": "^2.3.0"
     },
     "devDependencies": {

--- a/src/hooks/useFetchMore.ts
+++ b/src/hooks/useFetchMore.ts
@@ -1,4 +1,5 @@
 import { RefObject, useCallback, useEffect } from "react";
+import debounce from "lodash/debounce";
 
 type TProps = {
     loadMore: () => void;
@@ -7,6 +8,7 @@ type TProps = {
 
 /** A custom hook to load more items in the table on scroll to bottom of the table */
 export const useFetchMore = ({ loadMore, ref }: TProps) => {
+    const debouncedLoadMore = debounce(loadMore, 100);
     //called on scroll and possibly on mount to fetch more data as the user scrolls and reaches bottom of table
     const fetchMoreOnBottomReached = useCallback(
         (containerRefElement?: HTMLDivElement | null) => {
@@ -14,14 +16,14 @@ export const useFetchMore = ({ loadMore, ref }: TProps) => {
                 const { clientHeight, scrollHeight, scrollTop } =
                     containerRefElement;
                 //once the user has scrolled within 200px of the bottom of the table, fetch more data if we can
-                const isBottom = scrollHeight - scrollTop <= clientHeight + 200;
+                const isBottom = scrollHeight - scrollTop - clientHeight < 200;
 
                 if (isBottom) {
-                    loadMore();
+                    debouncedLoadMore();
                 }
             }
         },
-        [loadMore],
+        [debouncedLoadMore],
     );
 
     useEffect(() => {


### PR DESCRIPTION
- Added debounce so it doesn't spam loadMore as there are brief moments where it will constantly spam loadMore instead of waiting for it to finish.

### Before

https://github.com/user-attachments/assets/59e8255f-0369-46b2-a502-a628a9de3b75


### After

https://github.com/user-attachments/assets/b8afcddd-b1ed-491f-b98a-753a1c543eee


https://github.com/user-attachments/assets/bbf97ddd-bd07-4e95-9fce-3862a642663a

