### PR TITLE
feat: make action in notification optional

### DIFF
--- a/src/components/AppLayout/Notifications/Notification.tsx
+++ b/src/components/AppLayout/Notifications/Notification.tsx
@@ -20,11 +20,13 @@ export const Notification = ({
                     </div>
                 </div>
             </div>
-            <div className="notification__button-container">
-                <button className="notification__button" onClick={buttonAction}>
-                    {actionText}
-                </button>
-            </div>
+            {buttonAction && actionText && (
+                <div className="notification__button-container">
+                    <button className="notification__button" onClick={buttonAction}>
+                        {actionText}
+                    </button>
+                </div>
+            )}
         </div>
     );
 };

--- a/src/components/AppLayout/Notifications/__test__/notification.spec.tsx
+++ b/src/components/AppLayout/Notifications/__test__/notification.spec.tsx
@@ -4,9 +4,23 @@ import { Notification } from "../Notification";
 import userEvent from "@testing-library/user-event";
 
 describe("Notification Component", () => {
-    it("renders the notification with title, message, and button", async () => {
+    it("renders the notification with title, message", async () => {
+        const { getByText } = render(
+            <Notification
+                icon={<span>Icon</span>}
+                title="Test Title"
+                message="Test message"
+            />,
+        );
+
+        // Check if the title and message are in the document
+        expect(getByText("Test Title")).toBeInTheDocument();
+        expect(getByText("Test message")).toBeInTheDocument();
+    });
+
+    it("renders the action button if buttonAction and actionText are passed", async () => {
         const mockAction = jest.fn();
-        const { getByText, getByRole } = render(
+        const { getByRole } = render(
             <Notification
                 icon={<span>Icon</span>}
                 title="Test Title"
@@ -16,9 +30,22 @@ describe("Notification Component", () => {
             />,
         );
 
-        // Check if the title and message are in the document
-        expect(getByText("Test Title")).toBeInTheDocument();
-        expect(getByText("Test message")).toBeInTheDocument();
+        // Check if the button is rendered and clickable
+        const button = getByRole("button", { name: "Click Me" });
+        expect(button).toBeInTheDocument();
+    });
+
+    it("calls the action function when the button is clicked", async () => {
+        const mockAction = jest.fn();
+        const { getByRole } = render(
+            <Notification
+                icon={<span>Icon</span>}
+                title="Test Title"
+                message="Test message"
+                buttonAction={mockAction}
+                actionText="Click Me"
+            />,
+        );
 
         // Check if the button is rendered and clickable
         const button = getByRole("button", { name: "Click Me" });

--- a/src/components/AppLayout/Notifications/index.tsx
+++ b/src/components/AppLayout/Notifications/index.tsx
@@ -24,7 +24,7 @@ export const Notifications = ({
 
     useOnClickOutside(notificationsRef, (e) => {
         e.stopPropagation();
-        setIsOpen(!isOpen);
+        setIsOpen(false);
     });
 
     return (

--- a/src/components/AppLayout/Notifications/types.ts
+++ b/src/components/AppLayout/Notifications/types.ts
@@ -4,8 +4,8 @@ export type TNotificationObject = {
     icon: ReactNode;
     title: string;
     message: string;
-    buttonAction: () => void;
-    actionText: string;
+    buttonAction?: () => void;
+    actionText?: string;
 };
 export type TNotificationsProps = ComponentProps<"div"> & {
     notifications: TNotificationObject[];

--- a/stories/Notifications.stories.tsx
+++ b/stories/Notifications.stories.tsx
@@ -46,6 +46,11 @@ export const Default: Story = {
             },
             {
                 icon: <LegacyAnnouncementIcon width={16} height={16} />,
+                title: "Your account got verified!",
+                message: "Account verification is complete.",
+            },
+            {
+                icon: <LegacyAnnouncementIcon width={16} height={16} />,
                 title: "We’d love to hear your thoughts",
                 message: "Drop your review on Trustpilot.",
                 buttonAction: () => {


### PR DESCRIPTION
Some notifications will not require a button to be shown, so change it to be optional. 

![Screenshot 2024-08-13 at 13 28 47](https://github.com/user-attachments/assets/caf3064b-d7d3-4cb8-b7db-7a22ad348b7a)
