### PR TITLE
fix: add dropdown icon prop

### DIFF
--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -15,8 +15,8 @@ import "./Dropdown.scss";
 
 type InputProps = React.ComponentProps<typeof Input>;
 type TProps = HtmlHTMLAttributes<HTMLInputElement> & {
+    chevronIcon?: React.ReactNode;
     disabled?: boolean;
-    dropdownIcon?: React.ReactNode;
     emptyResultMessage?: string;
     errorMessage?: InputProps["message"];
     icon?: React.ReactNode;
@@ -37,8 +37,8 @@ type TProps = HtmlHTMLAttributes<HTMLInputElement> & {
 };
 
 export const Dropdown = ({
+    chevronIcon,
     disabled,
-    dropdownIcon,
     emptyResultMessage = "",
     errorMessage,
     icon = false,
@@ -161,7 +161,7 @@ export const Dropdown = ({
                             aria-expanded={isOpen}
                         >
                             {
-                                dropdownIcon ?? (
+                                chevronIcon ?? (
                                         <LegacyChevronDown2pxIcon
                                             className={clsx("deriv-dropdown__chevron", {
                                                 "deriv-dropdown__chevron--open": isOpen,

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -16,6 +16,7 @@ import "./Dropdown.scss";
 type InputProps = React.ComponentProps<typeof Input>;
 type TProps = HtmlHTMLAttributes<HTMLInputElement> & {
     disabled?: boolean;
+    dropdownIcon?: React.ReactNode;
     emptyResultMessage?: string;
     errorMessage?: InputProps["message"];
     icon?: React.ReactNode;
@@ -37,6 +38,7 @@ type TProps = HtmlHTMLAttributes<HTMLInputElement> & {
 
 export const Dropdown = ({
     disabled,
+    dropdownIcon,
     emptyResultMessage = "",
     errorMessage,
     icon = false,
@@ -158,14 +160,18 @@ export const Dropdown = ({
                             className="deriv-dropdown__button"
                             aria-expanded={isOpen}
                         >
-                            <LegacyChevronDown2pxIcon
-                                className={clsx("deriv-dropdown__chevron", {
-                                    "deriv-dropdown__chevron--open": isOpen,
-                                    "deriv-dropdown__chevron--disabled":
-                                        disabled,
-                                })}
-                                iconSize="xs"
-                            />
+                            {
+                                dropdownIcon ?? (
+                                        <LegacyChevronDown2pxIcon
+                                            className={clsx("deriv-dropdown__chevron", {
+                                                "deriv-dropdown__chevron--open": isOpen,
+                                                "deriv-dropdown__chevron--disabled":
+                                                    disabled,
+                                            })}
+                                            iconSize="xs"
+                                        />
+                                    )
+                            }
                         </button>
                     }
                     type="text"

--- a/stories/Dropdown.stories.ts
+++ b/stories/Dropdown.stories.ts
@@ -7,7 +7,6 @@ const meta = {
     tags: ["autodocs"],
     args: {
         disabled: false,
-        dropdownIcon: "",
         errorMessage: "Error message",
         icon: "",
         isRequired: true,

--- a/stories/Dropdown.stories.tsx
+++ b/stories/Dropdown.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react";
+import { LabelPairedSearchMdRegularIcon } from "@deriv/quill-icons";
 import { Dropdown } from "../src/components/Dropdown";
 
 const meta = {
@@ -74,5 +75,19 @@ export const PromptNoResults: Story = {
         ],
         label: "Choose an option",
         emptyResultMessage: "No search results",
+    },
+};
+
+export const ComboBoxWithIcon: Story = {
+    name: "ComboBox With passed Chevron Icon",
+    args: {
+        variant: "comboBox",
+        list: [
+            { text: "Option 1", value: "option1" },
+            { text: "Option 2", value: "option2" },
+            { text: "Option 3", value: "option3" },
+        ],
+        label: "Select an option",
+        chevronIcon: <LabelPairedSearchMdRegularIcon />,
     },
 };


### PR DESCRIPTION
Currently the dropdown component doesn't accept any prop for dropdown icon and takes the chevron as default. But there are cases where search icon / ellipsis is needed for the dropdowns. This PR adds a dropdownIcon prop to the component, so if the icon is passed, the passed icon will be taken, or else it defaults to chevron

<img width="349" alt="Screenshot 2024-08-21 at 10 26 19 AM" src="https://github.com/user-attachments/assets/9ccd5d1c-fd23-4c5c-b442-a4cd520e0fe4">
