### PR TITLE
maryia/refactor: improve types of notifications component

### DIFF
--- a/src/components/AppLayout/Notifications/index.tsx
+++ b/src/components/AppLayout/Notifications/index.tsx
@@ -20,7 +20,7 @@ export const Notifications = ({
     componentConfig,
     className,
     excludedClickOutsideClass = '',
-    loadMoreFunction,
+    loadMoreFunction = () => { },
     isLoading,
     ...rest
 }: Omit<TNotificationsProps, "style">) => {

--- a/src/components/AppLayout/Notifications/types.ts
+++ b/src/components/AppLayout/Notifications/types.ts
@@ -13,7 +13,7 @@ export type TNotificationsProps = ComponentProps<"div"> & {
     clearNotificationsCallback: () => void;
     setIsOpen: (state: boolean) => void;
     isOpen: boolean;
-    loadMoreFunction: () => void;
+    loadMoreFunction?: () => void;
     isLoading: boolean;
     componentConfig: {
         clearButtonText: string;


### PR DESCRIPTION
On the bot side, we don't use the `loadMoreFunction` property of the `Notifications` component. 
Let's make it optional instead of passing an empty function, which causes the eslint to fail.