### PR TITLE
[BOT]maryia/fix: remove the method that closes the modal upon clicking on the button clear all

### DIFF
--- a/src/components/AppLayout/Notifications/index.tsx
+++ b/src/components/AppLayout/Notifications/index.tsx
@@ -168,7 +168,6 @@ export const Notifications = ({
                                 })}
                                 onClick={() => {
                                     if (notifications.length > 0) {
-                                        setIsOpen(false);
                                         clearNotificationsCallback();
                                     }
                                 }}


### PR DESCRIPTION
fix: remove the method that closes the modal upon clicking on the button "clear all"

Since the main application notifications do not close the modal window by clicking on the “clear all” button and in the bot annonces we need the same approach, I propose to remove this line in general