### PR TITLE
Ameerul / Add Scroll To Accordion Functionality

### DIFF
--- a/src/components/Accordion/Accordion.scss
+++ b/src/components/Accordion/Accordion.scss
@@ -66,7 +66,7 @@ $animation-duration: 0.3s;
     }
     &__content {
         width: 100%;
-        overflow: auto;
+        overflow: scroll;
         opacity: 0;
         background-color: var(--content-bg-color);
         transition: all $animation-duration ease;


### PR DESCRIPTION
- Currently, the accordion component is not able to be scrolled to by whoever consumes it. Now users can pass a ref to the accordion, and a function to the component.
- The new function `onScrollToAccordion` which is optional, and it should be handled by the consumer as for my case, I needed the accordion to be scrolled to the top of the page, and this needs to be handled by the main div that surrounds all of my accordions.
- Also I changed the overflow value to scroll as using auto will add the scrollbar to the content as it opens, which causes it to shift the content. Scroll will already add it by default, and won't cause a shift.

### Scrollbar Content Shift Issue:

https://github.com/user-attachments/assets/ebf7a187-08ff-41e4-ad33-988c1edd8c81

### Scrollbar Content Shift Fix:

https://github.com/user-attachments/assets/fa536280-7920-4d02-be18-e782b5f9e6ee

### Accordion Scroll To:

https://github.com/user-attachments/assets/673e5f23-3eb5-45b0-9057-d185b732e0f0


