### PR TITLE
[FIX] Separator visibility

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.scss
@@ -1,10 +1,23 @@
 .deriv-breadcrumbs {
+    width: 100%;
     margin: 0;
     padding: 0;
 
     &__item {
         float: left;
         list-style-type: none;
+
+        @include rtl {
+            float: right;
+        }
+
+        &:not(:last-child) {
+            cursor: pointer;
+
+            .deriv-breadcrumbs__text:hover {
+                color: var(--du-text-general, #333333);
+            }
+        }
     }
 
     &__text {
@@ -13,19 +26,15 @@
         &--active {
             color: var(--du-text-prominent, #333333);
         }
+    }
 
-        &:not(:last-child) {
-            cursor: pointer;
-
-            &:hover {
-                color: var(--du-text-general, #333333);
-            }
-        }
+    &__separator-container {
+        cursor: default;
     }
 
     &__chevron-icon {
         margin: 0 5px;
-        vertical-align: middle;
+        vertical-align: sub;
 
         path {
             fill: var(--du-text-less-prominent, #999999);
@@ -33,6 +42,10 @@
 
         @include mobile {
             margin: 0 2.5px;
+        }
+
+        @include rtl {
+            transform: rotate(180deg);
         }
     }
 }

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -43,13 +43,16 @@ export const Breadcrumbs = ({
                         >
                             {item.text}
                         </Text>
-                        {!isLastItem &&
-                            (separator ?? (
-                                <LegacyChevronRight1pxIcon
-                                    className="deriv-breadcrumbs__chevron-icon"
-                                    iconSize="xs"
-                                />
-                            ))}
+                        {!isLastItem && (
+                            <span className="deriv-breadcrumbs__separator-container">
+                                {separator || (
+                                    <LegacyChevronRight1pxIcon
+                                        className="deriv-breadcrumbs__chevron-icon"
+                                        iconSize="xs"
+                                    />
+                                )}
+                            </span>
+                        )}
                     </li>
                 );
             })}

--- a/src/styles/abstracts/_layout.scss
+++ b/src/styles/abstracts/_layout.scss
@@ -1,0 +1,7 @@
+/*RTL Language Mixin*/
+
+@mixin rtl {
+    [dir="rtl"] & {
+        @content;
+    }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,4 +1,5 @@
 @import "./base/reset";
+@import "./abstracts/layout";
 @import "./abstracts/variables";
 @import "./abstracts/typography";
 @import "./abstracts/devices";


### PR DESCRIPTION
1. When we are passing separator prop as `separator={is_rtl && <LegacyChevronLeft1pxIcon />}` nothing is rendering because of `??` operator.
Fix it using `||` operator instead.
2. Minor fix for hover state and style
3. Add RTL mixin