### PR TITLE
fix: :ambulance: fix colors in Breadcrumbs

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/Breadcrumbs.scss
@@ -20,14 +20,6 @@
         }
     }
 
-    &__text {
-        color: var(--du-text-less-prominent, #999999);
-
-        &--active {
-            color: var(--du-text-prominent, #333333);
-        }
-    }
-
     &__separator-container {
         cursor: default;
     }

--- a/src/components/Breadcrumbs/index.tsx
+++ b/src/components/Breadcrumbs/index.tsx
@@ -35,11 +35,10 @@ export const Breadcrumbs = ({
                         className="deriv-breadcrumbs__item"
                     >
                         <Text
-                            className={clsx("deriv-breadcrumbs__text", {
-                                "deriv-breadcrumbs__text--active": isLastItem,
-                            })}
-                            size={textSize}
+                            className="deriv-breadcrumbs__text"
+                            color={isLastItem ? 'prominent' : 'less-prominent'}
                             onClick={() => handleOnClick(item)}
+                            size={textSize}
                         >
                             {item.text}
                         </Text>

--- a/src/components/Text/Text.scss
+++ b/src/components/Text/Text.scss
@@ -1,6 +1,6 @@
 // TODO: Refactor this file to use css variables
 $color-map: (
-    "prominent": var(--du-text-prominent),
+    "prominent": var(--du-text-prominent, #333333),
     "less-prominent": var(--du-text-less-prominent, #999999),
     "general": var(--du-text-general, #333333),
     "primary": var(--du-text-primary, #999999),


### PR DESCRIPTION
Resolve color issues caused by race conditions in the bundled CSS.

After bundling deriv-com/ui in deriv-app, the CSS of the Text component is overriding my custom styles in the Breadcrumbs component, even though the custom className in Text is defined after the base `deriv-text` classes. 

This can be addressed by directly passing the color prop to the Text component instead of relying on external style overrides.